### PR TITLE
Add chart tweak

### DIFF
--- a/R/addChart.R
+++ b/R/addChart.R
@@ -10,7 +10,7 @@
 #' @param repo_url Homepage for chart's code repository (if any)
 #' @param settings_url Homepage for chart's settings documentation
 #' @param main Name of the main function used to initialize the app. If the type is htmlwidgets, the js function must accept "location" and "settings" parameters (in that order) and have an .init() method, expecting a json data array. Otherwise, the r function should accept named data and settings parameters, and should be loaded in the user's namespace.
-#' @param type type of chart. Should be 'htmlwidget', 'static', 'plotly' or 'module'
+#' @param type type of chart. Should be 'static', 'plotly' or 'module'
 #' @param maxWidth max width for the widget in pixels
 #' @param requiredSettings array of text_key values (matching those used in settingsMetadata) for the required settings for this chart
 #' @param settingsLocation path where the custom settings will be loaded/saved. If metadata is not found in that location, it will be read from the package (e.g. safetyGraphics::settingsMetadata), and then written to the specified location once the new chart has been added.
@@ -28,7 +28,7 @@ addChart <- function(
   repo_url="",
   settings_url="",
   main="character",
-  type='htmlwidget',
+  type='static',
   maxWidth=1000,
   requiredSettings=c(""),
   settingsLocation=getwd(),

--- a/R/safetyGraphicsApp.R
+++ b/R/safetyGraphicsApp.R
@@ -20,6 +20,10 @@
 #' @export
 #'
 safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocation = NULL, customSettings="customSettings.R") {
+  
+  if(is.null(settingsLocation)){
+    settingsLocation <- getwd()    
+  }
 
   # pass charts to include
   shiny::shinyOptions(safetygraphics_charts = charts)
@@ -34,6 +38,7 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocatio
 
   # run the custom settings file (if it exists)
   customSettingsScript<-paste(settingsLocation, customSettings,sep="/")
+
   if(file.exists(customSettingsScript)){
     source(customSettingsScript)
   }

--- a/man/addChart.Rd
+++ b/man/addChart.Rd
@@ -5,7 +5,7 @@
 \title{Adds a new chart for use in the safetyGraphics shiny app}
 \usage{
 addChart(chart, label = "", description = "", repo_url = "",
-  settings_url = "", main = "character", type = "htmlwidget",
+  settings_url = "", main = "character", type = "static",
   maxWidth = 1000, requiredSettings = c(""),
   settingsLocation = getwd(), overwrite = TRUE)
 }
@@ -22,7 +22,7 @@ addChart(chart, label = "", description = "", repo_url = "",
 
 \item{main}{Name of the main function used to initialize the app. If the type is htmlwidgets, the js function must accept "location" and "settings" parameters (in that order) and have an .init() method, expecting a json data array. Otherwise, the r function should accept named data and settings parameters, and should be loaded in the user's namespace.}
 
-\item{type}{type of chart. Should be 'htmlwidget', 'static', 'plotly' or 'module'}
+\item{type}{type of chart. Should be 'static', 'plotly' or 'module'}
 
 \item{maxWidth}{max width for the widget in pixels}
 


### PR DESCRIPTION
Simplify workflow for adding a custom chart. User now just has to save `customSettings.R` and then call `setwd()` with the location of that file, and then initialize the app with `safetyGraphicsApp()`