### PR TITLE
Preload datafiles into app

### DIFF
--- a/R/safetyGraphicsApp.R
+++ b/R/safetyGraphicsApp.R
@@ -4,7 +4,7 @@
 #' @param maxFileSize maximum file size in MB allowed for file upload
 #' @param settingsLocation folder location of user-defined settings metadata. Files should be named settingsMetadata.rda, chartsMetadata.rda and standardsMetadata.rda and use the same structure established in the /data folder.
 #' @param customSettings Name of R script containing settings customizations to be run before the app is initialized. This is the recommended way to add additional charts (via addChart()), settings (addSetting()) and data standards (addStandard()). default = 'settingsLocation/customSettings.R'
-
+#' @param loadData Option to pre-load data into the app. Defaults to \code{TRUE}.
 #'
 #' @importFrom shiny runApp shinyOptions
 #' @import shinyjs
@@ -19,11 +19,11 @@
 #'
 #' @export
 #'
-safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocation = NULL, customSettings="customSettings.R") {
-  
-  if(is.null(settingsLocation)){
-    settingsLocation <- getwd()    
-  }
+safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL,
+                              settingsLocation = ".",  
+                              customSettings="customSettings.R", 
+                              loadData=FALSE) {
+
 
   # pass charts to include
   shiny::shinyOptions(safetygraphics_charts = charts)
@@ -37,13 +37,13 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocatio
   }
 
   # run the custom settings file (if it exists)
-  customSettingsScript<-paste(settingsLocation, customSettings,sep="/")
+  customSettingsScript<-file.path(settingsLocation, customSettings) #,sep="/")
 
   if(file.exists(customSettingsScript)){
     source(customSettingsScript)
   }
 
-  chartsMetaPath <- paste(settingsLocation,"chartsMetadata.Rds",sep="/")
+  chartsMetaPath <- file.path(settingsLocation,"chartsMetadata.Rds") #,sep="/")
   if(file.exists(chartsMetaPath)){
     options(sg_chartsMetadata=TRUE)
     options(sg_chartsMetadata_df=readRDS(chartsMetaPath))
@@ -54,7 +54,7 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocatio
 
   }
 
-  settingsMetaPath <- paste(settingsLocation,"settingsMetadata.Rds",sep="/")
+  settingsMetaPath <- file.path(settingsLocation,"settingsMetadata.Rds") #,sep="/")
   if(file.exists(settingsMetaPath)){
     options(sg_settingsMetadata=TRUE)
     options(sg_settingsMetadata_df=readRDS(settingsMetaPath))
@@ -63,13 +63,20 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL, settingsLocatio
     options(sg_settingsMetadata_df=NULL)
   }
 
-  standardsMetaPath <- paste(settingsLocation,"standardsMetadata.Rds",sep="/")
+  standardsMetaPath <- file.path(settingsLocation,"standardsMetadata.Rds") #,sep="/")
   if(file.exists(standardsMetaPath)){
     options(sg_standardsMetadata=TRUE)
     options(sg_standardsMetadata_df=readRDS(standardsMetaPath))
   } else {
     options(sg_standardsMetadata=FALSE)
     options(sg_standardsMetadata_df=NULL)
+  }
+  
+  # pre-load data into app
+  if (loadData){
+    shiny::shinyOptions(sg_loadData=TRUE)
+  } else {
+    shiny::shinyOptions(sg_loadData=FALSE)
   }
 
   path <- system.file("safetyGraphics_app", package = "safetyGraphics")

--- a/R/safetyGraphicsApp.R
+++ b/R/safetyGraphicsApp.R
@@ -37,13 +37,13 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL,
   }
 
   # run the custom settings file (if it exists)
-  customSettingsScript<-file.path(settingsLocation, customSettings) #,sep="/")
+  customSettingsScript<-file.path(settingsLocation, customSettings)  
 
   if(file.exists(customSettingsScript)){
     source(customSettingsScript)
   }
 
-  chartsMetaPath <- file.path(settingsLocation,"chartsMetadata.Rds") #,sep="/")
+  chartsMetaPath <- file.path(settingsLocation,"chartsMetadata.Rds")  
   if(file.exists(chartsMetaPath)){
     options(sg_chartsMetadata=TRUE)
     options(sg_chartsMetadata_df=readRDS(chartsMetaPath))
@@ -54,7 +54,7 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL,
 
   }
 
-  settingsMetaPath <- file.path(settingsLocation,"settingsMetadata.Rds") #,sep="/")
+  settingsMetaPath <- file.path(settingsLocation,"settingsMetadata.Rds")  
   if(file.exists(settingsMetaPath)){
     options(sg_settingsMetadata=TRUE)
     options(sg_settingsMetadata_df=readRDS(settingsMetaPath))
@@ -63,7 +63,7 @@ safetyGraphicsApp <- function(charts = NULL, maxFileSize = NULL,
     options(sg_settingsMetadata_df=NULL)
   }
 
-  standardsMetaPath <- file.path(settingsLocation,"standardsMetadata.Rds") #,sep="/")
+  standardsMetaPath <- file.path(settingsLocation,"standardsMetadata.Rds")  
   if(file.exists(standardsMetaPath)){
     options(sg_standardsMetadata=TRUE)
     options(sg_standardsMetadata_df=readRDS(standardsMetaPath))

--- a/R/safetyGraphicsApp.R
+++ b/R/safetyGraphicsApp.R
@@ -4,7 +4,7 @@
 #' @param maxFileSize maximum file size in MB allowed for file upload
 #' @param settingsLocation folder location of user-defined settings metadata. Files should be named settingsMetadata.rda, chartsMetadata.rda and standardsMetadata.rda and use the same structure established in the /data folder.
 #' @param customSettings Name of R script containing settings customizations to be run before the app is initialized. This is the recommended way to add additional charts (via addChart()), settings (addSetting()) and data standards (addStandard()). default = 'settingsLocation/customSettings.R'
-#' @param loadData Option to pre-load data into the app. Defaults to \code{TRUE}.
+#' @param loadData Option to pre-load data into the app. Defaults to \code{FALSE}.
 #'
 #' @importFrom shiny runApp shinyOptions
 #' @import shinyjs

--- a/inst/safetyGraphics_app/global.R
+++ b/inst/safetyGraphics_app/global.R
@@ -14,9 +14,13 @@ library(tidyr)
 library(shinybusy)
 
 # use metadata in user settings folder if provided
-if(!is.null(getShinyOption("settings_location"))){
+if (options('sg_chartsMetadata')[[1]]){
   chartsMetadata <-  options('sg_chartsMetadata_df')[[1]]
+}
+if (options('sg_settingsMetadata')[[1]]){
   settingsMetadata <-  options('sg_settingsMetadata_df')[[1]]
+}
+if (options('sg_standardsMetadata')[[1]]){
   standardsMetadata <-  options('sg_standardsMetadata_df')[[1]]
 }
 
@@ -28,6 +32,53 @@ if (!is.null(getShinyOption("safetygraphics_charts"))){
   all_charts <- chartsMetadata$chart
 }
 
+
+# Prepare initial datasets/labels (with info about standards) to be loaded into the app 
+# pre-load data into app if requested
+if(getShinyOption("sg_loadData")){
+  preload_data_list <- list()
+  
+  # names of data in environment
+  dat_names <- ls(pos=1)[sapply(ls(pos=1), function(x) inherits(get(x), "data.frame"))]
+  preload_data_list$data <- lapply(dat_names, function(x) {get(x)})
+  names(preload_data_list$data) <- dat_names
+  
+  # set all to not currently selected
+  preload_data_list$current <- c(1, rep(0, length(dat_names)-1))
+  
+  # detect standard for all datasets
+  preload_data_list$standard <- lapply(preload_data_list$data, function(x){ detectStandard(x) })
+
+  # get display name for all datasets
+  preload_data_list$display <- list()
+  
+  for (i in 1:length(dat_names)){
+    
+    temp_standard <- preload_data_list$standard[[i]]$standard
+    standard_label <- ifelse(temp_standard=="adam","AdAM",ifelse(temp_standard=="sdtm","SDTM",temp_standard))
+    if(temp_standard == "none") {
+      preload_data_list$display[[i]] <- HTML(paste0("<p>", names(preload_data_list$data)[i], " - <em style='font-size:12px;'>No Standard Detected</em></p>"))
+    } else if (preload_data_list$standard[[i]]$details[[temp_standard]]$match == "full") {
+      preload_data_list$display[[i]] <- HTML(paste0("<p>", names(preload_data_list$data)[i], " - <em style='color:green; font-size:12px;'>", standard_label, "</em></p>"))
+      # If partial data spec match - give the fraction of variables matched
+    } else {
+      
+      valid_count <- preload_data_list$standard[[i]]$details[[temp_standard]]$valid_count
+      total_count <- preload_data_list$standard[[i]]$details[[temp_standard]]$invalid_count + valid_count
+      
+      fraction_cols  <- paste0(valid_count, "/" ,total_count)
+      
+      preload_data_list$display[[i]] <- HTML(paste0("<p>", names(preload_data_list$data)[i], " - <em style='color:green; font-size:12px;'>", "Partial ",
+                                  standard_label, " (", fraction_cols, " data settings)",  "</em></p>"))
+    }
+  }
+} else {  # otherwise use example data
+  preload_data_list <- list(data = list("Example data" = adlbc),
+                            current = 1,
+                            standard = list(list("standard" = "adam", "details" = list("adam"=list("match"="full")))),
+                            display = list(HTML("<p>Example data - <em style='color:green; font-size:12px;'>ADaM</em></p>")))
+}
+
 ## source modules
 source('modules/renderSettings/renderSettingsUI.R')
 source('modules/renderSettings/renderSettings.R')
@@ -36,12 +87,7 @@ source('modules/renderChart/renderChartUI.R')
 source('modules/renderChart/renderChart.R')
 
 source('modules/renderReports/renderReportsUI.R')
-source('modules/renderReports/renderReports.R')
-
-# source('modules/renderChart/render_edish_chartUI.R')
-# source('modules/renderChart/render_edish_chart.R')
-# source('modules/renderChart/render_safetyhistogram_chartUI.R')
-# source('modules/renderChart/render_safetyhistogram_chart.R')
+source('modules/renderReports/renderReports.R') 
 
 source('modules/dataUpload/dataUploadUI.R')
 source('modules/dataUpload/dataUpload.R')

--- a/inst/safetyGraphics_app/modules/dataUpload/dataUpload.R
+++ b/inst/safetyGraphics_app/modules/dataUpload/dataUpload.R
@@ -33,8 +33,11 @@ dataUpload <- function(input, output, session){
 
   # initiate reactive values - list of uploaded data files
   # standard to imitate output of detectStandard.R
-  dd <- reactiveValues(data = list("Example data" = adlbc), current = 1, standard = list(list("standard" = "adam", "details" = list("adam"=list("match"="full")))))
+  dd <- reactiveValues(data = preload_data_list$data,
+                       current = preload_data_list$current,
+                       standard = preload_data_list$standard)
 
+  
   # modify reactive values when data is uploaded
   observeEvent(input$datafile,{
 
@@ -104,8 +107,10 @@ dataUpload <- function(input, output, session){
     return(choices)
   })
 
+
+  
   # update radio buttons to display dataset names and standards for selection
-  observeEvent(input$datafile, {
+ observeEvent(input$datafile, {
     req(data_choices())
     vals <- data_choices()
     names(vals) <- NULL
@@ -119,6 +124,7 @@ dataUpload <- function(input, output, session){
                        selected = prev_sel)
 
   })
+  
 
   # get selected dataset when selection changes
   data_selected <- eventReactive(input$select_file, {

--- a/inst/safetyGraphics_app/modules/dataUpload/dataUploadUI.R
+++ b/inst/safetyGraphics_app/modules/dataUpload/dataUploadUI.R
@@ -22,8 +22,11 @@ dataUploadUI <- function(id){
                h3("Data upload"),
                fileInput(ns("datafile"), "Upload a csv or sas7bdat file",accept = c(".sas7bdat", ".csv"), multiple = TRUE),
                radioButtons(ns("select_file"),"Select file for safetyGraphics charts",
-                            choiceNames = list(HTML("<p>Example data - <em style='color:green; font-size:12px;'>ADaM</em></p>")),
-                            choiceValues = "Example data")
+                            choiceNames = preload_data_list$display,
+                            choiceValues = names(preload_data_list$data))
+               # radioButtons(ns("select_file"),"Select file for safetyGraphics charts",
+               #              choiceNames = list(HTML("<p>Example data - <em style='color:green; font-size:12px;'>ADaM</em></p>")),
+               #              choiceValues = "Example data")
              )
       ),
       column(6,

--- a/man/safetyGraphicsApp.Rd
+++ b/man/safetyGraphicsApp.Rd
@@ -4,8 +4,13 @@
 \alias{safetyGraphicsApp}
 \title{Run the interactive safety graphics builder}
 \usage{
-safetyGraphicsApp(charts = NULL, maxFileSize = NULL,
-  settingsLocation = NULL, customSettings = "customSettings.R")
+safetyGraphicsApp(
+  charts = NULL,
+  maxFileSize = NULL,
+  settingsLocation = ".",
+  customSettings = "customSettings.R",
+  loadData = FALSE
+)
 }
 \arguments{
 \item{charts}{Character vector of charts to include}
@@ -15,6 +20,8 @@ safetyGraphicsApp(charts = NULL, maxFileSize = NULL,
 \item{settingsLocation}{folder location of user-defined settings metadata. Files should be named settingsMetadata.rda, chartsMetadata.rda and standardsMetadata.rda and use the same structure established in the /data folder.}
 
 \item{customSettings}{Name of R script containing settings customizations to be run before the app is initialized. This is the recommended way to add additional charts (via addChart()), settings (addSetting()) and data standards (addStandard()). default = 'settingsLocation/customSettings.R'}
+
+\item{loadData}{Option to pre-load data into the app. Defaults to \code{FALSE}.}
 }
 \description{
 Run the interactive safety graphics builder


### PR DESCRIPTION
- Add loadData option in safetyGraphicsApp - allows user to replace Example data with any data frames that exist in current R session (assumes these have been loaded into R session using code in customSettings.R)
- Fix #383 