### PR TITLE
adding metadata highlight

### DIFF
--- a/R/mod_settingsMapping.R
+++ b/R/mod_settingsMapping.R
@@ -70,7 +70,7 @@ settingsMapping <- function(input, output, session, metaIn, mapping){
             metadata_mapping(), 
             rownames = FALSE,
             options = list(paging=FALSE, ordering=FALSE),
-            class="compact"
+            class="compact metatable"
         )
     })
 

--- a/inst/safetyGraphics_app/www/index.css
+++ b/inst/safetyGraphics_app/www/index.css
@@ -44,7 +44,7 @@
   border-color:green;
 }
 
-table.dataTable tr > td:last-of-type, table.dataTable tr > th:last-of-type {
+table.metatable.dataTable tr > td:last-of-type, table.metatable.trdataTable tr > th:last-of-type {
   border-left:2px solid black;
   background:#d0d1e6;
 }


### PR DESCRIPTION
# Changelog

- Added a `metatable` class to the metadata table in `mod_settingsMapping.R`
- Updated CSS so that the logic of highlighting the last column only applies to table with the class `metatable`

This closes issue #467 [I hope!]