### PR TITLE
Remove chart if order is negative

### DIFF
--- a/R/makeChartConfig.R
+++ b/R/makeChartConfig.R
@@ -73,6 +73,12 @@ makeChartConfig <- function(dirs, sourceFiles=TRUE){
             chart$order
         ) %>% as.numeric
 
+        chart$export <- ifelse(
+            is.null(chart$export),
+            true,
+            chart$export
+        )
+
         return(chart)
     })
 

--- a/R/mod_reportsTab.R
+++ b/R/mod_reportsTab.R
@@ -47,10 +47,9 @@ reportsTab <- function(input, output, session, charts, data, mapping){
   # create checkbox for selecting charts of interest
   output$checkboxes <- renderUI({
     # no support for modules or broken widgets yet
-    noExport <- c("aeTimelines","hepexplorer","safetyShiftPlot","tplyr_shift")
     chart_type <- charts %>% map(., ~.$type) %>% unlist 
-    chart_name <- charts %>% map(., ~.$name) %>% unlist 
-    charts_keep <- ((! chart_type == "module") & (! chart_name %in% noExport))
+    chart_export <- charts %>% map(., ~.$export) %>% unlist 
+    charts_keep <- ((! chart_type == "module") & (chart_export))
     
     charts_labels <- charts %>% map(., ~ .$label) %>% unlist
     charts_vec <- names(charts)[charts_keep]

--- a/inst/report/safetyGraphicsReport.Rmd
+++ b/inst/report/safetyGraphicsReport.Rmd
@@ -48,7 +48,6 @@ create_chart <- function(chart, params){
           null = "null",  
         )
       }
-      widgetParams$ns <-chart$name  #Still not working quite right. May need to refactor widgets a bit to, since some use this parameter to select the location of the wrapper div. there's no easy way to set this to the random widget value (e.g. "htmlwidget-638ca0176b34007fbdf9")
       return(widgetParams)
     }
     


### PR DESCRIPTION
# Summary 

Remove chart when order is negative. Fix #524

# Test Notes

Set order to negative in a YAML files and make sure chart doesn't render.