### PR TITLE
Improve safetyGraphicsApp() params 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,8 +50,7 @@ Imports:
     shinyjs,
     shinyWidgets,
     stringr,
-    yaml,
-    pharmaRTF
+    yaml
 Remotes: safetyGraphics/safetyCharts
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -19,8 +19,9 @@ app_server <- function(meta, mapping, domainData, charts){
         #Initialize modules
         current_mapping<-callModule(mappingTab, "mapping", meta, domainData)
 
+        filter_domain <- ifelse(hasName(domainData, "dm"), "dm", names(domainData)[[1]])
         id_col <- reactive({
-            dm<-current_mapping()%>%filter(.data$domain=="dm")   
+            dm<-current_mapping()%>%filter(.data$domain==filter_domain)   
             id<-dm %>%filter(.data$text_key=="id_col")%>%pull(.data$current)
             return(id)
         })
@@ -29,13 +30,13 @@ app_server <- function(meta, mapping, domainData, charts){
             filterTab, 
             "filter", 
             domainData=domainData, 
-            filterDomain="dm", 
+            filterDomain=filter_domain, 
             id_col=id_col
         )
 
         callModule(settingsData, "dataSettings", domains = domainData)
         callModule(settingsMapping, "metaSettings", metadata=meta, mapping=current_mapping)
-        callModule(settingsCharts, "chartSettings",charts = charts)
+        callModule(settingsCharts, "chartSettings", charts = charts)
         callModule(homeTab, "home")
 
         #Initialize Chart UI - Adds subtabs to chart menu - this initializes initializes chart UIs
@@ -56,14 +57,14 @@ app_server <- function(meta, mapping, domainData, charts){
         # pass all charts, filtered data, and current mappings to reports/export tab
         callModule(reportsTab, "reports", charts = charts, data = filtered_data, mapping = current_mapping)
         
-
         #participant count in header
-        shinyjs::html("header-count", paste(dim(domainData[["dm"]])[1]))
-        shinyjs::html("header-total", paste(dim(domainData[["dm"]])[1]))
-        observe({
-            req(filtered_data)
-            shinyjs::html("header-count", paste0(dim(filtered_data()[["dm"]])[1]))
-        })
+        # ids <- domainData[[filter_domain]][[id_col()]]
+        # shinyjs::html("header-count", paste(dim(domainData[["dm"]])[1]))
+        # shinyjs::html("header-total", paste(dim(domainData[["dm"]])[1]))
+        # observe({
+        #     req(filtered_data)
+        #     shinyjs::html("header-count", paste0(dim(filtered_data()[["dm"]])[1]))
+        # })
     }
     return(server)
 }

--- a/R/app_startup.R
+++ b/R/app_startup.R
@@ -6,6 +6,7 @@
 #' @param meta list of configuration metadata 
 #' @param charts list of charts
 #' @param mapping initial data mapping
+#' @param filterDomain domain used for the data/filter tab. Demographics ("`dm`") is used by default. Using a domain that is not one record per participant is not recommended. 
 #' @param chartSettingsPaths character vector with paths to chart setting yaml files
 #' 
 #' @return List of elements for used to initialize the shiny app with the following parameters
@@ -18,7 +19,7 @@
 #' }
 #' 
 #' @export
-app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, chartSettingsPaths=NULL){
+app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, filterDomain=NULL, chartSettingsPaths=NULL){
     # Process charts metadata
     if(is.null(charts)){
         if(is.null(chartSettingsPaths)){
@@ -47,7 +48,8 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, cha
         charts=charts,
         domainData=domainData,
         mapping=mapping,
-        standards=standards
+        standards=standards,
+        filterDomain=filterDomain
     ) 
     
     # Check config

--- a/R/app_startup.R
+++ b/R/app_startup.R
@@ -35,7 +35,7 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, fil
         message("Dropping ", length(chart_drops), " chart(s) with missing data domains: ", paste(names(chart_drops), collapse=", "))
     }
     charts <- charts %>% purrr::keep(~all(.x$domain %in% names(domainData)))
-    
+
     # get the data standards
     standards <- names(domainData) %>% lapply(function(domain){
         return(detectStandard(domain=domain, data = domainData[[domain]], meta=meta))
@@ -48,6 +48,12 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, fil
             return(standard[["mapping"]])
         })
         mapping<-bind_rows(mapping_list, .id = "domain")
+    }
+
+    # Set filterDomain to null if no data exists
+    if(!filterDomain %in% names(domainData)){
+        message("No data found for specified filter domain of '",filterDomain,"', so filter functionality has been deactivated.")
+        filterDomain<-NULL
     }
 
     config<-list(

--- a/R/app_startup.R
+++ b/R/app_startup.R
@@ -29,6 +29,13 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, fil
         }
     }
 
+    #Drop charts if data for required domain(s) is not found
+    chart_drops <- charts %>% purrr::keep(~(!all(.x$domain %in% names(domainData))))
+    if(length(chart_drops)>0){
+        message("Dropping ", length(chart_drops), " chart(s) with missing data domains: ", paste(names(chart_drops), collapse=", "))
+    }
+    charts <- charts %>% purrr::keep(~all(.x$domain %in% names(domainData)))
+    
     # get the data standards
     standards <- names(domainData) %>% lapply(function(domain){
         return(detectStandard(domain=domain, data = domainData[[domain]], meta=meta))

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -23,7 +23,7 @@ app_ui <- function(meta, domainData, mapping, standards){
     participant_badge<-tags$script(
         HTML(
             "var header = $('.navbar> .container-fluid');
-            header.append('<div id=\"population-header\" class=\"badge\" title=\"Selected Participants\" ><span id=\"header-count\"></span>/<span id=\"header-total\"></span></div>');"
+            header.append('<div id=\"population-header\" class=\"badge\" title=\"Selected Participants\" ></div>');"
         )
     )
 
@@ -45,7 +45,7 @@ app_ui <- function(meta, domainData, mapping, standards){
             navbarMenu('Data',icon=icon("database"),
                 tabPanel("Preview", icon=icon("table"), settingsDataUI("dataSettings")),
                 tabPanel("Mapping", icon=icon("map"), mappingTabUI("mapping", meta, domainData, mapping, standards)),
-                tabPanel("Filtering", icon=icon("filter"), filterTabUI("filter","dm"))
+                tabPanel("Filtering", icon=icon("filter"), filterTabUI("filter"))
             ),
             navbarMenu('Charts', icon=icon("chart-bar")),
             tabPanel("Reports", icon=icon("file-alt"), reportsTabUI("reports")),

--- a/R/generateMappingList.R
+++ b/R/generateMappingList.R
@@ -23,7 +23,7 @@ generateMappingList <- function(settingsDF, domain, pull=FALSE){
     )
   }
 
-  if(domain=="multiple"){
+  if(length(domain)>1){
     return(settingsList)
   }else{
     return(settingsList[[domain]])

--- a/R/makeChartConfig.R
+++ b/R/makeChartConfig.R
@@ -16,7 +16,7 @@
 #'  \item{"name"}{ Name of the chart. Also the name of the element in the list - e.g. charts$aeExplorer$name is "aeExplorer"}
 #'  \item{"label"}{ Short description of the chart }
 #'  \item{"type"}{ Type of chart; options are: 'htmlwidget', 'module', 'plot', 'table', 'html' or 'plotly'.}
-#'  \item{"domain"}{ Data domain. Should correspond to a domain in `meta` or be set to "multiple" }
+#'  \item{"domain"}{ Data domain. Should correspond to one or more domains in `meta` }
 #'  \item{"package"}{ Primary package (if any). Other packages can be loaded directly in workflow functions. }
 #'  \item{"order"}{ Integer order in which to display the chart. If order is a negative number, the chart is dropped. }
 #'  \item{"export"}{ Logical flag indicating whether the chart can be exported to an html report. True by default, except for when type is module. }

--- a/R/mod_chartsTab.R
+++ b/R/mod_chartsTab.R
@@ -30,7 +30,7 @@ chartsTabUI <- function(id, chart){
     
     labelDiv<-div(tags$small("Chart"),chart$label)
     typeDiv<-div(tags$small("Type"), chart$type)
-    dataDiv<-div(tags$small("Data Domain"), chart$domain)
+    dataDiv<-div(tags$small("Data Domain"), paste(chart$domain,collapse=" "))
     header<-div(
         labelDiv,
         typeDiv,
@@ -77,7 +77,7 @@ chartsTab <- function(input, output, session, chart, data, mapping){
         settingsList <-  safetyGraphics::generateMappingList(mapping(), domain=chart$domain)
 
         #subset data to specific domain (if specified)
-        if(chart$domain=="multiple"){
+        if(length(chart$domain)>1){
             domainData <- data()
         }else{
             domainData<- data()[[chart$domain]]

--- a/R/mod_filterTab.R
+++ b/R/mod_filterTab.R
@@ -9,7 +9,7 @@
 #' 
 #' @export
 
-filterTabUI <- function(id, filterDomain = "dm"){  
+filterTabUI <- function(id){  
     ns <- NS(id)
 
     filter_ui<-list(

--- a/R/mod_filterTab.R
+++ b/R/mod_filterTab.R
@@ -2,7 +2,6 @@
 #' @description  UI that facilitates the filtering data with datamods::filter_data_ui
 #'
 #' @param id module id
-#' @param filterDomain data set for the domain
 #' 
 #' @import datamods
 #' @importFrom shiny dataTableOutput

--- a/R/mod_homeTab.R
+++ b/R/mod_homeTab.R
@@ -7,31 +7,10 @@
 
 homeTabUI <- function(id){
   ns <- NS(id)
-  tabsetPanel(
-    tabPanel(
-      "About",
-      fluidRow(
-        column(width=8, style='font-size:20px', uiOutput(outputId = ns("about"))),
-        column(width=4, imageOutput(outputId = ns("hex")))
-      )
-    ),
-    tabPanel(
-      "Shiny App User Guide",
-      tags$iframe(
-        style="height:800px; width:100%; scrolling=yes;",  
-        `data-type`="iframe",
-        src = "https://cran.r-project.org/web/packages/safetyGraphics/vignettes/shinyUserGuide.html"
-      )
-    ),
-    tabPanel(
-      "Hep Explorer workflow",
-      tags$iframe(
-        style="height:800px; width:100%; scrolling=yes;",  
-        `data-type`="iframe",
-        src = "https://cdn.jsdelivr.net/gh/SafetyGraphics/SafetyGraphics.github.io/guide/HepExplorerWorkflow_v1_1.pdf"
-      )
-    )
-  ) 
+  fluidRow(
+    column(width=8, style='font-size:20px', uiOutput(outputId = ns("about"))),
+    column(width=4, imageOutput(outputId = ns("hex")))
+  )  
 }
 
 #' @title  home tab - server
@@ -46,53 +25,21 @@ homeTabUI <- function(id){
 homeTab <- function(input, output, session){
   ns <- session$ns
   output$about <- renderUI({
-    HTML('<h1> <b> Welcome to the Safety Graphics Shiny App  </b> </h1>
-         <p> The Safety Graphics Shiny app is an interactive tool for evaluating clinical trial safety using
-         a flexible data pipeline. This application and corresponding
-    <a href="https://cran.r-project.org/web/packages/safetyGraphics/index.html">safetyGraphics</a>
-         R package have been developed as part of the <a href="https://safetygraphics.github.io/">Interactive Safety Graphics (ISG) workstream</a>
-        of the ASA Biopharm-DIA Safety Working Group. </p>
-         <h3><i> Using the app</i></h3>
-        <p>Detailed instructions about using the app can be found in our
-        <a href="https://cran.r-project.org/web/packages/safetyGraphics/vignettes/shinyUserGuide.html">vignette</a>. In short,
-        the user will begin by loading a data file, adjust settings as needed and view the interactive charts.
-        Finally, the user may export a self-contained, fully reproducible snapshot of the charts that can be easily shared with others.</p>
-        <h3><i> Clinical Workflow </i></h3>
-        This shiny app has been developed in parallel with a well-documented <a href="https://github.com/SafetyGraphics/SafetyGraphics.github.io/raw/master/guide/HepExplorerWorkflow_v1_1.pdf">clinical workflow</a>
- for monitoring hepatotoxicity. The workflow, written by expert physicians, provides a detailed description of how the interactive graphics can be used for clinical safety monitoring.
-        <h3><i> Interactive Charts </i></h3>
-        <p> The included interactive charts are built using the <code>htmlwidgets</code> framework in R. The code libraries
-        and configuration details for the underlying JavaScript charts are located below.
-        <ul>
-        <li>Hepatic Safety Explorer -
-<a href="https://github.com/SafetyGraphics/hep-explorer">Library</a>,
-<a href="https://github.com/SafetyGraphics/hep-explorer/wiki/Configuration">Configuration</a>
-        </li>
-        <li>Histogram -
-<a href="https://github.com/RhoInc/safety-histogram">Library</a>,
-<a href="https://github.com/RhoInc/safety-histogram/wiki/Configuration">Configuration</a></li>
-        <li>Outlier Explorer -
-<a href="https://github.com/RhoInc/safety-outlier-explorer">Library</a>,
-<a href="https://github.com/RhoInc/safety-outlier-explorer/wiki/Configuration">Configuration</a></li>
-        <li>Shift Plot -
-<a href="https://github.com/RhoInc/safety-shift-plot">Library</a>,
-<a href="https://github.com/RhoInc/safety-shift-plot/wiki/Configuration">Configuration</a></li>
-        <li>Results Over Time -
-<a href="https://github.com/RhoInc/safety-results-over-time">Library</a>,
-<a href="https://github.com/RhoInc/safety-results-over-time/wiki/Configuration">Configuration</a></li>
-        <li>Paneled Outlier Explorer -
-<a href="https://github.com/RhoInc/paneled-outlier-explorer">Library</a>,
-<a href="https://github.com/RhoInc/paneled-outlier-explorer/wiki/Configuration">Configuration</a></li></ul>
-        </p>
-<br>
-         <p>For more information about <code>safetyGraphics</code>, please visit our
-<a href="https://github.com/SafetyGraphics/safetyGraphics">GitHub repository</a>.  We also welcome your suggestions in our
-<a href="https://github.com/SafetyGraphics/safetyGraphics/issues">issue tracker</a>.
-         </p>')
+    HTML('
+    <h1> <b> Welcome to the Safety Graphics Shiny App  </b> </h1>
+    <p> The Safety Graphics Shiny app is an interactive tool for evaluating clinical trial safety using a flexible data pipeline. This application and corresponding <a href="https://cran.r-project.org/web/packages/safetyGraphics/index.html">{safetyGraphics}</a> R package have been developed as part of the <a href="https://safetygraphics.github.io/">Interactive Safety Graphics (ISG) workstream</a> of the ASA Biopharm-DIA Safety Working Group. </p>
+    <h3><i> Using the app</i></h3>
+    <p>Detailed instructions about using the app can be found in our <a href="https://cran.r-project.org/web/packages/safetyGraphics/vignettes/shinyUserGuide.html">vignette</a>. In short, the user will initialize the app with thier data, adjust settings as needed and view the interactive charts. Finally, the user may export a self-contained, fully reproducible snapshot of the charts that can be easily shared with others.</p>
+    <h3><i> Charts </i></h3>
+    <p> The app is built to support a wide variety of chart types including static plots (e.g. from {ggplot2}), shiny modules, {htmlwidgets} and even static outputs like rtfs. Several pre-configured charts are included in the companion <a href="https://www.github.com/safetyGraphics/safetyCharts">{safetyCharts}</a> R Package, and are available by default in the app. Other charts can be added using the process descibed in this <a href="https://cran.r-project.org/web/packages/safetyGraphics/vignettes/shinyUserGuide.html">vignette</a>. 
     
+    <p> For more information about {safetyGraphics}, please visit our <a href="https://github.com/SafetyGraphics/safetyGraphics">GitHub repository</a>.  We also welcome your suggestions in our <a href="https://github.com/SafetyGraphics/safetyGraphics/issues">issue tracker</a>.
+    </p>')
   })
   
   output$hex <- renderImage({
-    list(src = system.file("safetyGraphicsHex/safetyGraphicsHex.png", package = "safetyGraphics"), width="60%")
-  }, deleteFile = FALSE)
+    list(
+      src = system.file("safetyGraphicsHex/safetyGraphicsHex.png", package = "safetyGraphics"), width="60%")
+  }, deleteFile = FALSE
+  )
 }

--- a/R/mod_mappingTab.R
+++ b/R/mod_mappingTab.R
@@ -26,9 +26,12 @@ mappingTabUI <- function(id, meta, domainData, mappings=NULL, standards=NULL){
     is.character(meta$text_key)
   )
   
-  #intialize a domain mapping for each domain in the metadata
+  #intialize a domain mapping for each domain in the metadata with a data set in domainData
   domain_ui <- list()
-  domains <- unique(meta$domain)
+  metaDomains <- unique(meta$domain)
+  dataDomains <- names(domainData)
+  domains <- metaDomains[metaDomains %in% dataDomains]
+
   for(i in 1:length(domains)){
     current_meta <- meta %>% filter(domain == !!domains[i])
     domain<-domains[i]
@@ -67,7 +70,15 @@ mappingTabUI <- function(id, meta, domainData, mappings=NULL, standards=NULL){
 #' @export
 
 mappingTab <- function(input, output, session, meta, domainData){
-  domain_ids <- unique(meta$domain)
+  metaDomains <- unique(meta$domain)
+  dataDomains <- names(domainData)
+  domain_ids <- metaDomains[metaDomains %in% dataDomains]
+
+  if(length(domain_ids) < length(metaDomains)){
+    domains_noData <- metaDomains[!(metaDomains %in% dataDomains)]
+    message("No data sets provided for the following domains listed in metadata: ",paste(domains_noData, collapse=", "))
+  }
+
   names(domain_ids)<-domain_ids # so that lapply() creates a named list below
   domain_modules <- domain_ids %>% lapply(function(domain){
     this_meta<- meta%>%filter(domain==!!domain)

--- a/R/safetyGraphicsApp.R
+++ b/R/safetyGraphicsApp.R
@@ -4,6 +4,7 @@
 #' @param domainData named list of data.frames to be loaded in to the app. Sample AdAM data from the safetyData package used by default
 #' @param charts data.frame of charts to be used in the app
 #' @param mapping data.frame specifying the initial values for each data mapping. If no mapping is provided, the app will attempt to generate one via \code{detectStandard()}
+#' @param filterDomain domain used for the data/filter tab. Demographics ("`dm`") is used by default. Using a domain that is not one record per participant is not recommended. 
 #' @param chartSettingsPaths path(s) where customization functions are saved relative to your working directory. All charts can have itialization (e.g. myChart_Init.R) and static charts can have charting functions (e.g. myGraphic_Chart.R).   All R files in this folder are sourced and files with the correct naming convention are linked to the chart. See the Custom Charts vignette for more details. 
 #'
 #' @import shiny
@@ -20,14 +21,14 @@ safetyGraphicsApp <- function(
   meta = safetyGraphics::meta, 
   charts=NULL,
   mapping=NULL,
+  filterDomain="dm",
   chartSettingsPaths = NULL
 ){
-
-  config <- app_startup(domainData, meta, charts, mapping, chartSettingsPaths)
+  config <- app_startup(domainData, meta, charts, mapping, filterDomain, chartSettingsPaths)
 
   app <- shinyApp(
     ui =  app_ui(config$meta, config$domainData, config$mapping, config$standards),
-    server = app_server(config$meta, config$mapping, config$domainData, config$charts)
+    server = app_server(config$meta, config$mapping, config$domainData, config$charts, config$filterDomain)
   )
   runApp(app, launch.browser = TRUE)
 }

--- a/man/app_server.Rd
+++ b/man/app_server.Rd
@@ -4,7 +4,7 @@
 \alias{app_server}
 \title{Server for the default safetyGraphics shiny app}
 \usage{
-app_server(meta, mapping, domainData, charts)
+app_server(meta, mapping, domainData, charts, filterDomain)
 }
 \arguments{
 \item{meta}{data frame containing the metadata for use in the app. See the preloaded file (\code{?safetyGraphics::meta}) for more data specifications and details. Defaults to \code{safetyGraphics::meta}.}
@@ -14,6 +14,8 @@ app_server(meta, mapping, domainData, charts)
 \item{domainData}{named list of data.frames to be loaded in to the app.}
 
 \item{charts}{list of charts to include in the app}
+
+\item{filterDomain}{domain used for the data/filter tab. Demographics ("\code{dm}") is used by default. Using a domain that is not one record per participant is not recommended.}
 }
 \description{
 This function returns a server function suitable for use in shiny::runApp()

--- a/man/app_startup.Rd
+++ b/man/app_startup.Rd
@@ -9,6 +9,7 @@ app_startup(
   meta = NULL,
   charts = NULL,
   mapping = NULL,
+  filterDomain = NULL,
   chartSettingsPaths = NULL
 )
 }
@@ -20,6 +21,8 @@ app_startup(
 \item{charts}{list of charts}
 
 \item{mapping}{initial data mapping}
+
+\item{filterDomain}{domain used for the data/filter tab. Demographics ("\code{dm}") is used by default. Using a domain that is not one record per participant is not recommended.}
 
 \item{chartSettingsPaths}{character vector with paths to chart setting yaml files}
 }

--- a/man/filterTabUI.Rd
+++ b/man/filterTabUI.Rd
@@ -4,7 +4,7 @@
 \alias{filterTabUI}
 \title{filterTabUI}
 \usage{
-filterTabUI(id, filterDomain = "dm")
+filterTabUI(id)
 }
 \arguments{
 \item{id}{module id}

--- a/man/filterTabUI.Rd
+++ b/man/filterTabUI.Rd
@@ -8,8 +8,6 @@ filterTabUI(id)
 }
 \arguments{
 \item{id}{module id}
-
-\item{filterDomain}{data set for the domain}
 }
 \description{
 UI that facilitates the filtering data with datamods::filter_data_ui

--- a/man/makeChartConfig.Rd
+++ b/man/makeChartConfig.Rd
@@ -27,7 +27,7 @@ returns a named list of charts derived from YAML files. Each element of the list
 \item{"name"}{ Name of the chart. Also the name of the element in the list - e.g. charts$aeExplorer$name is "aeExplorer"}
 \item{"label"}{ Short description of the chart }
 \item{"type"}{ Type of chart; options are: 'htmlwidget', 'module', 'plot', 'table', 'html' or 'plotly'.}
-\item{"domain"}{ Data domain. Should correspond to a domain in \code{meta} or be set to "multiple" }
+\item{"domain"}{ Data domain. Should correspond to one or more domains in \code{meta} }
 \item{"package"}{ Primary package (if any). Other packages can be loaded directly in workflow functions. }
 \item{"order"}{ Integer order in which to display the chart. If order is a negative number, the chart is dropped. }
 \item{"export"}{ Logical flag indicating whether the chart can be exported to an html report. True by default, except for when type is module. }

--- a/man/safetyGraphicsApp.Rd
+++ b/man/safetyGraphicsApp.Rd
@@ -10,6 +10,7 @@ safetyGraphicsApp(
   meta = safetyGraphics::meta,
   charts = NULL,
   mapping = NULL,
+  filterDomain = "dm",
   chartSettingsPaths = NULL
 )
 }
@@ -21,6 +22,8 @@ safetyGraphicsApp(
 \item{charts}{data.frame of charts to be used in the app}
 
 \item{mapping}{data.frame specifying the initial values for each data mapping. If no mapping is provided, the app will attempt to generate one via \code{detectStandard()}}
+
+\item{filterDomain}{domain used for the data/filter tab. Demographics ("\code{dm}") is used by default. Using a domain that is not one record per participant is not recommended.}
 
 \item{chartSettingsPaths}{path(s) where customization functions are saved relative to your working directory. All charts can have itialization (e.g. myChart_Init.R) and static charts can have charting functions (e.g. myGraphic_Chart.R).   All R files in this folder are sourced and files with the correct naming convention are linked to the chart. See the Custom Charts vignette for more details.}
 }


### PR DESCRIPTION
# Summary

This PR adds guard rails for the parameters passed to the `safetyGraphicsApp()` function. This should help to facilitate loading custom data. In particular, the following issues are addressed: 
- Ignore metadata for missing data domains - previously app would bomb. fixes #546
- Make the filter tab optional. Deactivate if specified `filterDomain` is not provided. fixes #547 
- Drop charts if required data domains are not provided - previously app would bomb when the chart was clicked. fixes #550 

Review with: https://github.com/SafetyGraphics/safetyCharts/pull/60 

# Test Notes

Run the first 4 examples on this [wiki page](https://github.com/SafetyGraphics/safetyGraphics/wiki/Vignette:-Shiny-App-Customization-Cookbook) and make sure that we don't get any errors