### PR TITLE
Minor charting workflow tweaks

### DIFF
--- a/R/mod_chartsTab.R
+++ b/R/mod_chartsTab.R
@@ -19,7 +19,7 @@ chartsTabUI <- function(id, chart){
         chartWrap <- chartsRenderModuleUI(id=ns("wrap"), chart$functions[[chart$workflow$ui]])
     }else if(tolower(chart$type=="htmlwidget")){
         #render the widget 
-        chartWrap<-chartsRenderWidgetUI(id=ns("wrap"),chart=chart$name, package=chart$package)
+        chartWrap<-chartsRenderWidgetUI(id=ns("wrap"),chart=chart$workflow$widget, package=chart$package)
     }else{
         #create the static or plotly chart
         chartWrap<-chartsRenderStaticUI(id=ns("wrap"), type=chart$type)
@@ -81,11 +81,11 @@ chartsTab <- function(input, output, session, chart, data, mapping){
         )
     }else if(tolower(chart$type=="htmlwidget")){
         message("chartsTab() is initializing a widget at ", ns("wrap"))
-        message("chart is ", chart$name, "; package is ", chart$package)
+        message("chart is ", chart$workflow$widget, "; package is ", chart$package)
         callModule(
             module=chartsRenderWidget,
             id="wrap",
-            chart=chart$name,
+            chart=chart$workflow$widget,
             package=chart$package,
             params=params
         )

--- a/R/mod_reportsTab.R
+++ b/R/mod_reportsTab.R
@@ -15,7 +15,6 @@ reportsTabUI <- function(id){
         wellPanel(
           class="reportPanel",
           h3("Export Charts"),
-          span("Note: AE Timelines, Hepatic Explorer and Shift plot export is temporarily disabled, but will be included in v2.0. Charts implemented using shiny modules are not currently able to be exported, but may be added at a later date."),
           hr(),
           uiOutput(ns("checkboxes")),
           downloadButton(ns("reportDL"), "Export Chart(s)")

--- a/inst/report/safetyGraphicsReport.Rmd
+++ b/inst/report/safetyGraphicsReport.Rmd
@@ -53,7 +53,7 @@ create_chart <- function(chart, params){
     
     # shiny render function for the widget 
     htmlwidgets::createWidget(
-      name = chart$name,
+      name = chart$workflow$widget,
       widgetParams(params),
       package = chart$package,
       sizingPolicy = htmlwidgets::sizingPolicy(viewer.suppress=TRUE, browser.external = TRUE),     

--- a/inst/report/safetyGraphicsReport.Rmd
+++ b/inst/report/safetyGraphicsReport.Rmd
@@ -18,7 +18,7 @@ params:
 create_chart_params <- function(data, chart, mapping){
   settingsList <-  safetyGraphics::generateMappingList(mapping, domain=chart$domain)
   #subset data to specific domain (if specified)
-  if(chart$domain=="multiple"){
+  if(length(chart$domain)>1){
     domainData <- data
   }else{
     domainData<- data[[chart$domain]]


### PR DESCRIPTION
# Overview

Quick technical updates - no new functionality. Fixes #443 #582.

# Test notes

Run the app and make sure no widgets bomb, and that exports work as expected. Exports are painfully slow, so I tested them 1 at a time. I'm honestly thinking that we might just allow exports for single charts until we improve performance there ... 

Side note re: @samussiah's question in #503 - I cloned a yaml in safetyCharts to do a quick check regarding whether if you could make duplicate widgets now, and it seems to work fine ... 
