### PR TITLE
minor UI tweaks in mapping tab. 

### DIFF
--- a/R/app_startup.R
+++ b/R/app_startup.R
@@ -69,7 +69,6 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, aut
     # generate mappings and data standards
     mappingObj <- makeMapping(domainData, meta, autoMapping, mapping)
 
-    print(mappingObj)
     config<-list(
         meta=meta,
         charts=charts,

--- a/R/app_startup.R
+++ b/R/app_startup.R
@@ -69,12 +69,13 @@ app_startup<-function(domainData=NULL, meta=NULL, charts=NULL, mapping=NULL, aut
     # generate mappings and data standards
     mappingObj <- makeMapping(domainData, meta, autoMapping, mapping)
 
+    print(mappingObj)
     config<-list(
         meta=meta,
         charts=charts,
         domainData=domainData,
         mapping=mappingObj$mapping,
-        standards=mappingObj$standards,
+        standards=mappingObj$standard,
         filterDomain=filterDomain
     ) 
 

--- a/R/mod_mappingTab.R
+++ b/R/mod_mappingTab.R
@@ -31,7 +31,6 @@ mappingTabUI <- function(id, meta, domainData, mappings=NULL, standards=NULL){
   metaDomains <- unique(meta$domain)
   dataDomains <- names(domainData)
   domains <- metaDomains[metaDomains %in% dataDomains]
-  print(standards)
   
   for(i in 1:length(domains)){
     

--- a/R/mod_mappingTab.R
+++ b/R/mod_mappingTab.R
@@ -31,8 +31,10 @@ mappingTabUI <- function(id, meta, domainData, mappings=NULL, standards=NULL){
   metaDomains <- unique(meta$domain)
   dataDomains <- names(domainData)
   domains <- metaDomains[metaDomains %in% dataDomains]
-
+  print(standards)
+  
   for(i in 1:length(domains)){
+    
     current_meta <- meta %>% filter(domain == !!domains[i])
     domain<-domains[i]
     current_mapping <- mappings %>% filter(domain %in% !!domains[i]) %>% select(-"domain")
@@ -55,8 +57,10 @@ mappingTabUI <- function(id, meta, domainData, mappings=NULL, standards=NULL){
       )
     )
   }
-  domain_ui<- list(      
-    checkboxInput(ns("toggleData"), "Show Data Previews?", TRUE),
+  domain_ui<- list(
+    h1("Data Mapping"),
+    span("This page dynamically establishes which columns and fields from the loaded data map to different chart properties. When possible, data standards are automatically detected and values are pre-filled."),
+    checkboxInput(ns("toggleData"), "Show Data Previews?", FALSE),
     br(),
     domain_ui
   )


### PR DESCRIPTION
# Overview

Minor updates in mapping tab:
- Deselect the data preview checkbox by default
- Add title and description
- Fix minor bug that stopped data standard in mapping header for each domain from renderering #527 

fixes #608

# Test notes

Run the app and make sure the mapping tab updates are looking good. 
