### PR TITLE
Allow non-standard data in  autoMapping

### DIFF
--- a/R/makeMapping.R
+++ b/R/makeMapping.R
@@ -21,8 +21,13 @@ makeMapping <- function(domainData, meta, autoMapping, customMapping ){
         })
         names(standards)<-names(domainData)
         
-        auto_mapping_list <- standards %>% map(~.x$mapping)
-        auto_mapping_df<-bind_rows(auto_mapping_list, .id = "domain") %>% select(-.data$valid)
+        auto_mapping_list <- standards %>% map(function(standard){
+            if(standard$standard=="none"){
+                return(data.frame(domain=character(), text_key=character(), current=character(), valid=logical()))
+            }else{
+                return(standard$mapping)
+            }
+        })        auto_mapping_df<-bind_rows(auto_mapping_list, .id = "domain") %>% select(-.data$valid)
     }else{
         # otherwise initialize NULL standards/mapping
         standards<-NULL 


### PR DESCRIPTION
# Summary 

Fixes bug that came up when fully non-standard data was provided in autoMapping workflow. See #642 for details. 

# Test Notes

This should run without errors, and the mapping tab should generate as usual. 
```
safetyGraphicsApp(domainData=list(labs=iris))
```